### PR TITLE
2nd embedded org.threeten.bp packaging fix

### DIFF
--- a/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
+++ b/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
@@ -1,0 +1,4 @@
+#
+# for gwt to ignore the 2nd "copy" of org.three.bp under walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.zone
+#
+**/bp/zone/org/**

--- a/src/main/java/walkingkooka/j2cl/java/util/timezone/zonerulesreader/org/threeten/bp/zone/ZoneRules.java
+++ b/src/main/java/walkingkooka/j2cl/java/util/timezone/zonerulesreader/org/threeten/bp/zone/ZoneRules.java
@@ -40,19 +40,15 @@ import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.Loca
 import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.LocalTime;
 import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.ZoneOffset;
 import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.jdk8.Jdk8Methods;
-import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.zone.org.threeten.bp.zone.TzdbZoneRulesProvider;
 import walkingkooka.j2cl.locale.Calendar;
 import walkingkooka.j2cl.locale.GregorianCalendar;
 import walkingkooka.j2cl.locale.TimeZoneOffsetAndDaylightSavings;
 
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.ZoneId;
@@ -85,20 +81,6 @@ import java.util.List;
  */
 public abstract class ZoneRules implements TimeZoneOffsetAndDaylightSavings {
 
-    static {
-        try {
-            String libDir = System.getProperty("java.home") + File.separator + "lib";
-            try (DataInputStream dis = new DataInputStream(
-                    new BufferedInputStream(new FileInputStream(
-                            new File(libDir, "tzdb.dat"))))) {
-                walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.zone.org.threeten.bp.zone.ZoneRulesProvider.registerProvider(new TzdbZoneRulesProvider(dis));
-
-            }
-        } catch (final IOException cause) {
-            throw new Error("Unable to load tzdb.dat", cause);
-        }
-    }
-
     @GwtIncompatible
     public static void main(final String[] args) throws Exception {
         final StandardZoneRules rules = (StandardZoneRules)of(java.time.ZoneId.of("Australia/Sydney"));
@@ -115,9 +97,6 @@ public abstract class ZoneRules implements TimeZoneOffsetAndDaylightSavings {
      */
     @GwtIncompatible
     public static ZoneRules of(final java.time.ZoneId zoneId) throws Exception {
-        final java.time.zone.ZoneRules rules = zoneId.getRules();
-        byte[] zoneBytes;
-
         // There are two copies of bp310 in this repo
         // - walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp has a few classes taken from from j2cl-java-time.
         //   these are a bare minimum and used in tests to verify that the StandardZoneRules created here can be compared

--- a/src/main/java/walkingkooka/j2cl/java/util/timezone/zonerulesreader/org/threeten/bp/zone/org/threeten/bp/zone/ZoneRulesProvider.java
+++ b/src/main/java/walkingkooka/j2cl/java/util/timezone/zonerulesreader/org/threeten/bp/zone/org/threeten/bp/zone/ZoneRulesProvider.java
@@ -36,6 +36,11 @@ import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.zone
 import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.zone.org.threeten.bp.ZonedDateTime;
 import walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.zone.org.threeten.bp.jdk8.Jdk8Methods;
 
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -308,4 +313,20 @@ public abstract class ZoneRulesProvider {
         return false;
     }
 
+    // j2cl-java-util-timezone-ZoneRulesReader: Added here to lazy init from jre/lib/tzdb.dat
+    // must be last in this class so all other static fields are already set before this is called.
+
+    static {
+        try {
+            String libDir = System.getProperty("java.home") + File.separator + "lib";
+            try (DataInputStream dis = new DataInputStream(
+                    new BufferedInputStream(new FileInputStream(
+                            new File(libDir, "tzdb.dat"))))) {
+                ZoneRulesProvider.registerProvider(new TzdbZoneRulesProvider(dis));
+
+            }
+        } catch (final IOException cause) {
+            throw new Error("Unable to load java.home/lib/tzdb.dat", cause);
+        }
+    }
 }


### PR DESCRIPTION
- This needs to be visible to the j2cl-java-util-TimeZone-annotation-processor but is not translatable and should be ignored by gwt and j2cl.
- Moved static init to walkingkooka.j2cl.java.util.timezone.zonerulesreader.org.threeten.bp.zone.org.threeten.bp.zone.TzdbZoneRulesProvider, fixing invalid import fails.