### PR TITLE
POM: maven-central-snapshots FIX

### DIFF
--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -32,8 +32,8 @@
                 </repository>
 
                 <repository>
-                    <id>google-sonatype-snapshots</id>
-                    <url>https://oss.sonatype.org/content/repositories/google-snapshots/</url>
+                    <id>maven.repository.snapshots</id>
+                    <url>https://central.sonatype.org/repository/maven-snapshots/</url>
                     <releases>
                         <enabled>true</enabled>
                         <updatePolicy>daily</updatePolicy>


### PR DESCRIPTION
- Previous commit failed to replace all google-snapshot entries